### PR TITLE
Compress Wasm files

### DIFF
--- a/memory-serve-macros/src/utils.rs
+++ b/memory-serve-macros/src/utils.rs
@@ -16,6 +16,7 @@ const COMPRESS_TYPES: &[&str] = &[
     "application/xml",
     "text/xml",
     "image/svg+xml",
+    "application/wasm",
 ];
 
 fn path_to_route(base: &Path, path: &Path) -> String {

--- a/memory-serve/src/asset.rs
+++ b/memory-serve/src/asset.rs
@@ -21,6 +21,7 @@ pub const COMPRESS_TYPES: &[&str] = &[
     "application/xml",
     "text/xml",
     "image/svg+xml",
+    "application/wasm",
 ];
 
 const BROTLI_ENCODING: &str = "br";


### PR DESCRIPTION
This enables compression for application/wasm mime types.

Thanks for making this library! I'm using it for a [Leptos](leptos.dev) app and the main reason I wanted compression was to reduce the main Wasm file size.

Here's a source that says it's recommended to compress Wasm in case that's in question: https://rustwasm.github.io/docs/book/reference/code-size.html#why-care-about-code-size

For me, this decreased the Wasm file size from 961 kB to 271 kB using brotli.