### PR TITLE
Add back alt js mime for backwards compatibility

### DIFF
--- a/memory-serve-macros/src/utils.rs
+++ b/memory-serve-macros/src/utils.rs
@@ -12,7 +12,7 @@ const COMPRESS_TYPES: &[&str] = &[
     "text/css",
     "application/json",
     "text/javascript",
-    "text/javascript",
+    "application/javascript",
     "application/xml",
     "text/xml",
     "image/svg+xml",

--- a/memory-serve/src/asset.rs
+++ b/memory-serve/src/asset.rs
@@ -17,7 +17,7 @@ pub const COMPRESS_TYPES: &[&str] = &[
     "text/css",
     "application/json",
     "text/javascript",
-    "text/javascript",
+    "application/javascript",
     "application/xml",
     "text/xml",
     "image/svg+xml",


### PR DESCRIPTION
I noticed while reviewing the latest changes that in https://github.com/tweedegolf/memory-serve/commit/b55342eed9e7e0f76048c5135d64ea6e6bc72f1a all instances of `application/javascript` were changed to be `text/javascript`, but `text/javascript` was already there in several places in addition to`application/javascript` so now it's duplicated.

Example:
https://github.com/tweedegolf/memory-serve/blob/b55342eed9e7e0f76048c5135d64ea6e6bc72f1a/memory-serve/src/asset.rs#L19-L20

I think the after noticing that it was already including both in some places you would want to instead simply add `text/javascript` to the one place it was missing. That's the most backwards compatible and what I did in this PR. It wouldn't bother me if you wanted to just remove the duplicates instead, I just made the PR to save you some time so I did what I thought you'd want.