### PR TITLE
Write to stderr, not stdout, during `load_assets`

### DIFF
--- a/memory-serve-macros/src/lib.rs
+++ b/memory-serve-macros/src/lib.rs
@@ -10,7 +10,7 @@ pub fn load_assets(input: TokenStream) -> TokenStream {
 
     fn log(msg: &str) {
         if std::env::var(QUIET_ENV_NAME) != Ok("1".to_string()) {
-            println!("  memory_serve: {msg}");
+            eprintln!("  memory_serve: {msg}");
         }
     }
 


### PR DESCRIPTION
I'm packaging up a crate that I've written using cargo-deb, which writes the name of the generated deb file to stdout, which I then capture, i.e. there's a line of my build script which is

```bash
DEB_FILE=$(cargo deb --target aarch64-unknown-linux-gnu)
```

When I started using memory-serve, because memory-serve writes to stdout, this gets captured.
By writing to stderr, not stdout, the output is still visible to the user, but no longer piped futher down build pipelines, which I think is more correct.